### PR TITLE
fix(FEV-837): QnA wrapping text in the middle of the word

### DIFF
--- a/src/components/trimmed-text/trimmedText.scss
+++ b/src/components/trimmed-text/trimmedText.scss
@@ -1,5 +1,5 @@
 .text {
-  word-break: break-all;
+  word-break: normal;
   white-space: pre-wrap;
   -webkit-user-select: text;
   -moz-user-select: text;

--- a/src/components/trimmed-text/trimmedText.tsx
+++ b/src/components/trimmed-text/trimmedText.tsx
@@ -1,6 +1,7 @@
 import { h, Component } from "preact";
 import * as styles from "./trimmedText.scss";
 import { LinkifyString } from "@playkit-js-contrib/linkify";
+import { Utils } from "../../utils";
 
 interface TrimmedTextProps {
     maxLength: number;
@@ -30,7 +31,7 @@ export class TrimmedText extends Component<TrimmedTextProps, TrimmedTextState> {
             <span>
                 <span className={styles.text}>
                     <LinkifyString
-                        text={isTrimmed ? `${text.substring(0, maxLength).trim()}...` : text}
+                        text={isTrimmed ? `${Utils.wordBoundaryTrim(text, maxLength)}...` : text}
                     />
                 </span>
                 <button

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,4 +201,12 @@ export class Utils {
     public static isMessageInTimeFrame(qnaMessage: QnaMessage) {
         return qnaMessage.createdAt.getTime() >= new Date().getTime() - NewMessageTimeDelay;
     }
+
+    public static wordBoundaryTrim = (
+        text: string,
+        maxLength: number
+      ): string => {
+        const subString = text.substring(0, maxLength);
+        return subString.substr(0, subString.lastIndexOf(' '));
+      };
 }


### PR DESCRIPTION
1) use word "boundary trim" method to shortcut long messages;
2) set 'normal' word-break css property to avoid break words
 
<img width="280" alt="Screen Shot 2021-04-20 at 11 19 16 AM" src="https://user-images.githubusercontent.com/51074448/115375464-7f8dba00-a1d6-11eb-971a-44512f00cdcb.png">

