### PR TITLE
fix(fev-837): ie11 issue for word breaks;

### DIFF
--- a/src/components/trimmed-text/trimmedText.scss
+++ b/src/components/trimmed-text/trimmedText.scss
@@ -1,4 +1,5 @@
 .text {
+  display: table-cell;
   word-break: normal;
   white-space: pre-wrap;
   -webkit-user-select: text;


### PR DESCRIPTION
`word-break` css property doesn't work in IE11, so `display: table-cell` solution to resolve word-break issue