### PR TITLE
fix(fec-11639): webcast Q&A icons multiplied

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,9 @@
     "@playkit-js-contrib/cli": "1.1.0",
     "@playkit-js-contrib/common": "^4.1.10",
     "@playkit-js-contrib/linkify": "^4.1.3",
-    "@playkit-js-contrib/plugin": "^4.1.10",
+    "@playkit-js-contrib/plugin": "^4.1.12",
     "@playkit-js-contrib/push-notifications": "^4.1.10",
-    "@playkit-js-contrib/ui": "^4.1.10",
+    "@playkit-js-contrib/ui": "^4.1.12",
     "classnames": "^2.2.6",
     "kaltura-typescript-client": "file:libs/kaltura-typescript-client-7.0.0-v20190324-101134.tgz"
   },

--- a/src/qna-plugin.tsx
+++ b/src/qna-plugin.tsx
@@ -153,6 +153,9 @@ export class QnaPlugin implements OnMediaLoad, OnPluginSetup, OnMediaUnload {
   }
 
   onMediaLoad(): void {
+    if (this._kitchenSinkItem) {
+      return;
+    }
     this._addPlayerListeners();
     const {
       playerConfig: { sources }
@@ -161,7 +164,7 @@ export class QnaPlugin implements OnMediaLoad, OnPluginSetup, OnMediaUnload {
     this._loading = true;
     this._hasError = false;
     //Q&A kitchenSink and push notifications are not available during VOD
-    if (sources.type !== ("Vod" as any) && !this._kitchenSinkItem) {
+    if (sources.type !== ("Vod" as any)) {
       this._addKitchenSinkItem();
       //push notification event handlers were set during pluginSetup,
       //on each media load we need to register for relevant entryId / userId notifications

--- a/src/qna-plugin.tsx
+++ b/src/qna-plugin.tsx
@@ -161,7 +161,7 @@ export class QnaPlugin implements OnMediaLoad, OnPluginSetup, OnMediaUnload {
     this._loading = true;
     this._hasError = false;
     //Q&A kitchenSink and push notifications are not available during VOD
-    if (sources.type !== ("Vod" as any)) {
+    if (sources.type !== ("Vod" as any) && !this._kitchenSinkItem) {
       this._addKitchenSinkItem();
       //push notification event handlers were set during pluginSetup,
       //on each media load we need to register for relevant entryId / userId notifications

--- a/src/qna-plugin.tsx
+++ b/src/qna-plugin.tsx
@@ -226,7 +226,7 @@ export class QnaPlugin implements OnMediaLoad, OnPluginSetup, OnMediaUnload {
     this._aoaAdapter.reset();
     this._kitchenSinkMessages.reset();
     this._chatMessagesAdapter.reset();
-    //todo [sa] remove kitchenSink item
+    this._kitchenSinkItem = null;
   }
 
   //todo [sakal] add onPluginDestroy


### PR DESCRIPTION
**the issue:**
we have 2 use-cases that can cause multiple Q&A icons:
1. failover primary to backup and vice-versa - **working as expected**:
as a result of player.reset, unloadMedia and loadMedia are working as expected and contib is cleaning the icons.
2. broadcast is offline (both streams are down), executing attachMedia and detachMedia - **having multiple icons**:
player.reset is not part of the flow in this use-case.
detachMedia is being executed, which is not calling unloadMedia. Therefore, icon is not being cleaned. Then when loadMedia is triggered, another icon is being added to player.

**the solution:**
resetting kitchenSinkItem obj in unloadMedia.
checking if there is a kitchenSinkItem that already exists, before creating new one.

**Note:**
The current fix _will_ fix the issue for 2nd use-case, however, root cause is not really solved.
Root issue is that contrib is doing the cleaning as a result of player.reset, which is only triggered for the 1st use-case. In addition, in the 2nd use-case player.reset is not triggered, but loadMedia is, which causes the multiple icons.

Solves [FEC-11639](https://kaltura.atlassian.net/browse/FEC-11639)