### PR TITLE
fix(FEV-1347): The qna plugin does rendered in side-panel

### DIFF
--- a/src/qna-plugin.tsx
+++ b/src/qna-plugin.tsx
@@ -200,7 +200,7 @@ export class QnaPlugin extends KalturaPlayer.core.BasePlugin {
       },
       presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live, ReservedPresetNames.Ads],
       position: this.config.position,
-      expandMode: this.config.expandMode,
+      expandMode: this.config.expandMode === SidePanelModes.ALONGSIDE ? SidePanelModes.ALONGSIDE : SidePanelModes.OVER,
       onActivate: () => {
         this._pluginState = PluginStates.OPENED;
         this._updateMenuIcon(false);


### PR DESCRIPTION
protect expandMode configuration from unsupported values