### PR TITLE
fix(SUP-38006):Live Q&A issue on V7 player

### DIFF
--- a/src/components/auto-expand-text-area/autoExpandTextArea.tsx
+++ b/src/components/auto-expand-text-area/autoExpandTextArea.tsx
@@ -3,13 +3,6 @@ import {A11yWrapper} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import * as styles from './autoExpandTextArea.scss';
 import classNames from 'classnames';
 
-const {withText, Text} = KalturaPlayer.ui.preacti18n;
-
-const translates = {
-  placeholder: <Text id="qna.type_private_question">Type a private question</Text>,
-  sendTitle: <Text id="qna.send">Send</Text>
-};
-
 interface AutoExpandTextAreaProps {
   placeholder?: string;
   sendTitle?: string;
@@ -31,7 +24,6 @@ interface AutoExpandTextAreaState {
 const MAX_NUM_OF_CHARS = 500;
 const MAX_HEIGHT = 103;
 
-@withText(translates)
 export class AutoExpandTextArea extends Component<AutoExpandTextAreaProps, AutoExpandTextAreaState> {
   private _textareaContainer: any = null;
   private _textAreaRef: HTMLTextAreaElement | null = null;

--- a/src/components/kitchen-sink/kitchenSink.tsx
+++ b/src/components/kitchen-sink/kitchenSink.tsx
@@ -29,7 +29,9 @@ const translates = {
   emptyQuestions: <Text id="qna.empty_questions">No Questions Yet</Text>,
   typeQuestion: <Text id="qna.type_question">Type your first question below</Text>,
   qnaLabel: <Text id="qna.qna">Q&A</Text>,
-  hidePlugin: <Text id="qna.hide_plugin">Hide QnA</Text>
+  hidePlugin: <Text id="qna.hide_plugin">Hide QnA</Text>,
+  placeholder: <Text id="qna.type_private_question">Type a private question</Text>,
+  sendTitle: <Text id="qna.send">Send</Text>
 };
 
 interface KitchenSinkTranslates {
@@ -41,6 +43,8 @@ interface KitchenSinkTranslates {
   emptyQuestions?: string;
   typeQuestion?: string;
   hidePlugin?: string;
+  placeholder?:string;
+  sendTitle?: string;
 }
 
 export interface KitchenSinkProps {
@@ -246,6 +250,8 @@ export class KitchenSink extends Component<KitchenSinkProps & KitchenSinkTransla
                 enableAnimation={true}
                 onFocusIn={this._handleTextAreaFocusIn}
                 onFocusOut={this._trackScrolling}
+                placeholder={this.props.placeholder}
+                sendTitle={this.props.sendTitle}
               />
             )}
           </div>

--- a/src/components/thread/thread.tsx
+++ b/src/components/thread/thread.tsx
@@ -22,6 +22,7 @@ const translates = ({thread: {replies}}: ThreadProps) => ({
   resend: <Text id="qna.resend">Resend</Text>,
   new_messages: <Text id="qna.new_messages">Thread contains new messages</Text>,
   sending: <Text id="qna.sending">Sending...</Text>,
+  sendTitle: <Text id="qna.send">Send</Text>,
   replies: (
     <Text
       id="qna.replies"
@@ -41,6 +42,7 @@ interface Translates {
   resend?: string;
   new_messages?: string;
   sending?: string;
+  sendTitle?: string;
   replies?: string;
 }
 
@@ -231,6 +233,7 @@ export class Thread extends Component<ThreadProps & Translates, ThreadState> {
             alwaysOpen={true}
             disabled={thread.deliveryStatus !== MessageDeliveryStatus.CREATED}
             onFocusOut={this.handleAutoExpandTextAreaFocusOut}
+            sendTitle={this.props.sendTitle}
           />
         </div>
 


### PR DESCRIPTION
the issue:
when send question and click on reply and start to type, some buttons (send new question, volume, settings) stop reacting

solution:
remove the wrapper for AutoExpandTextArea and send the translations as props