### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,5 @@ const NAME = __NAME__;
 export {QnaPlugin as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'qna';
+export const pluginName: string = 'qna';
 KalturaPlayer.core.registerPlugin(pluginName, QnaPlugin);

--- a/src/qna-plugin.tsx
+++ b/src/qna-plugin.tsx
@@ -14,6 +14,7 @@ import {icons} from './components/icons';
 import {PluginStates, QnaPluginConfig, TimedMetadataEvent, CuePoint, ModeratorSettings} from './types';
 import {ui} from '@playkit-js/kaltura-player-js';
 import {Utils} from './utils';
+import { pluginName } from "./index";
 const {SidePanelModes, SidePanelPositions, ReservedPresetNames} = ui;
 
 const {Text} = KalturaPlayer.ui.preacti18n;
@@ -213,9 +214,14 @@ export class QnaPlugin extends KalturaPlayer.core.BasePlugin {
       expandMode: this.config.expandMode === SidePanelModes.ALONGSIDE ? SidePanelModes.ALONGSIDE : SidePanelModes.OVER,
       onDeactivate: this._deactivatePlugin
     }) as number;
-
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     this._pluginIcon = this.upperBarManager!.add({
-      label: 'Q&A',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      displayName: 'Q&A',
+      ariaLabel: 'Q&A',
+      order: 20,
       svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
       onClick: this._handleClickOnPluginIcon as () => void,
       component: () => {


### PR DESCRIPTION
**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-transcript/pull/175
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-moderation/pull/74
https://github.com/kaltura/playkit-js-playlist/pull/53
https://github.com/kaltura/playkit-js-related/pull/61
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-info/pull/90
https://github.com/kaltura/playkit-js-downloads/pull/39