### PR TITLE
fix(ADA-1736) - Tooltip strict position

### DIFF
--- a/src/components/plugin-button/pluginButton.tsx
+++ b/src/components/plugin-button/pluginButton.tsx
@@ -25,7 +25,7 @@ interface QnaPluginButtonProps {
 
 export const QnaPluginButton = withText(translates)(({isActive, showIndication, setRef, ...otherProps}: QnaPluginButtonProps) => {
   return (
-    <Tooltip label={otherProps.label} type="bottom">
+    <Tooltip label={otherProps.label} type="bottom-left" strictPosition={true}>
         <button
           data-testid={'qna_pluginButton'}
           aria-label={otherProps.label}

--- a/src/components/plugin-button/pluginButton.tsx
+++ b/src/components/plugin-button/pluginButton.tsx
@@ -25,7 +25,7 @@ interface QnaPluginButtonProps {
 
 export const QnaPluginButton = withText(translates)(({isActive, showIndication, setRef, ...otherProps}: QnaPluginButtonProps) => {
   return (
-    <Tooltip label={otherProps.label} type="bottom-left" strictPosition={true}>
+    <Tooltip label={otherProps.label} type="bottom-left" strictPosition>
         <button
           data-testid={'qna_pluginButton'}
           aria-label={otherProps.label}


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1736. 
It sets the Tooltip position to always be bottom-left.